### PR TITLE
Dont parse `json-schema/lib/validate.js` in order to avoid "define cannot be used indirect" error

### DIFF
--- a/webpack/make-webpack-config.js
+++ b/webpack/make-webpack-config.js
@@ -160,7 +160,8 @@ module.exports = function( opts ) {
 		output: output,
 		externals: externals,
 		module: {
-			loaders: [ asyncLoader ].concat( loadersByExtension( loaders ) ).concat( loadersByExtension( stylesheetLoaders ) ).concat( additionalLoaders )
+			loaders: [ asyncLoader ].concat( loadersByExtension( loaders ) ).concat( loadersByExtension( stylesheetLoaders ) ).concat( additionalLoaders ),
+			noParse: /node_modules\/json-schema\/lib\/validate\.js/
 		},
 		devtool: opts.devtool,
 		debug: opts.debug,


### PR DESCRIPTION
- See `https://github.com/webpack/webpack/issues/138`

Re Issue #1 